### PR TITLE
Remove blank container

### DIFF
--- a/src/Plugin/Field/FieldWidget/BootstrapLayoutClassesWidget.php
+++ b/src/Plugin/Field/FieldWidget/BootstrapLayoutClassesWidget.php
@@ -210,15 +210,15 @@ class BootstrapLayoutClassesWidget extends WidgetBase {
     $selects = [];
     if ($this->getSetting('col') || self::hasAny($values,
         ['col', 'col-sm', 'col-md', 'col-lg', 'col-xl'])) {
-      $selects['col'] = [$this->t('Width'), $options_width];
+      $selects['col'] = [$this->t('Container Width'), $options_width];
     }
     if ($this->getSetting('offset') || self::hasAny($values,
         ['offset', 'offset-sm', 'offset-md', 'offset-lg', 'offset-xl'])) {
-      $selects['offset'] = [$this->t('Offset'), $options_offset];
+      $selects['offset'] = [$this->t('Container Offset'), $options_offset];
     }
     if ($this->getSetting('order') || self::hasAny($values,
         ['order', 'order-sm', 'order-md', 'order-lg', 'order-xl'])) {
-      $selects['order'] = [$this->t('Order'), $options_order];
+      $selects['order'] = [$this->t('Container Order'), $options_order];
     }
 
     if (!empty($selects)) {
@@ -227,11 +227,11 @@ class BootstrapLayoutClassesWidget extends WidgetBase {
         // '#caption' => t('Layout Options'),
         '#header' => [
           $this->t('Option'),
-          $this->t('Standard'),
-          'Small',
-          'Medium',
-          'Large',
-          'Extra Large',
+          $this->t('Base/Default'),
+          'Small ≥576px',
+          'Medium ≥768px',
+          'Large ≥992px',
+          'Extra Large ≥1200px',
         ],
       ];
     }

--- a/src/Plugin/Field/FieldWidget/BootstrapLayoutClassesWidget.php
+++ b/src/Plugin/Field/FieldWidget/BootstrapLayoutClassesWidget.php
@@ -139,7 +139,6 @@ class BootstrapLayoutClassesWidget extends WidgetBase {
     $options_container = [
       'container' => 'Container',
       'container-fluid' => 'Fluid',
-      '' => '',
     ];
     // '#empty_option' => '--',
     $options_width = [


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Bootstrap Options](https://kanopi.teamwork.com/app/tasks/29406164)

> As a developer, I need to remove the blank container option. I have also updated the width, offset, and order language.

## Steps to Validate
1. Verify that the Container option defaults to "Container" and only has 2 options - Container, Fluid
2. Verify that the width, offset, and order options now say Container Width, Container Offset, Container Order and specify breakpoint pixels
